### PR TITLE
Support pluralization

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,11 @@ z.setErrorMap(makeZodI18nMap(i18n))
 
 ## Plurals
 
-Messages using `maximum`, `minimum` or `keys` can be converted to the plural form.
+Messages using `count`, `maximum`, `minimum`, `keys` or `value` can be converted to the plural form using [vue-i18n pluralization feature](https://vue-i18n.intlify.dev/guide/essentials/pluralization.html#basic-usage)
 
 ```json
 {
-    "exact_one": "String must contain exactly {{minimum}} character",
-    "exact_other": "String must contain exactly {{minimum}} characters"
+    "exact": "String must contain exactly {{minimum}} character | String must contain exactly {{minimum}} characters"
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ const PLURAL_KEYS = [
     'minimum',
     'maximum',
     'keys',
-    'value'
+    'value',
 ]
 
 function retrieveCount(options: i18nOptions): number | undefined {
@@ -56,7 +56,7 @@ function makeZodI18nMap(i18n: I18n, key = 'errors'): ZodErrorMap {
             const messageKey = [
                 `${key}.${message}WithPath`,
                 `${key}.${message}`,
-                message
+                message,
             ].find(k => te(k))
 
             if (!messageKey)

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,24 @@ type i18nOptions = {
     [key: string]: unknown
 }
 
+const PLURAL_KEYS = [
+    'count',
+    'minimum',
+    'maximum',
+    'keys',
+    'value'
+]
+
+function retrieveCount(options: i18nOptions): number | undefined {
+    for (const k of PLURAL_KEYS) {
+        if (k in options && typeof options[k] === 'number') {
+            return options[k]
+        }
+    }
+
+    return undefined
+}
+
 function makeZodI18nMap(i18n: I18n, key = 'errors'): ZodErrorMap {
     return (issue: ZodIssueOptionalMessage, ctx: ErrorMapCtx): { message: string } => {
         let message: string
@@ -31,17 +49,22 @@ function makeZodI18nMap(i18n: I18n, key = 'errors'): ZodErrorMap {
         const te = i18n.global.te
         const d = i18n.global.d as ComposerDateTimeFormatting
 
-        const translateLabel = (message: string, options: i18nOptions) => {
-            if (te(`${key}.${message}WithPath`)) {
-                return t(`${key}.${message}WithPath`, options)
-            }
-            if (te(`${key}.${message}`)) {
-                return t(`${key}.${message}`, options)
-            }
-            if (te(message)) {
-                return t(message, options)
-            }
-            return message
+        const translateLabel = (message: string, _options: i18nOptions) => {
+            const options = { named: _options }
+            const count: number | undefined = retrieveCount(options.named)
+
+            const messageKey = [
+                `${key}.${message}WithPath`,
+                `${key}.${message}`,
+                message
+            ].find(k => te(k))
+
+            if (!messageKey)
+                return message
+
+            return count !== undefined
+                ? t(messageKey, count, options)
+                : t(messageKey, options)
         }
 
         switch (issue.code) {

--- a/test/makeZodI18nMap.ts
+++ b/test/makeZodI18nMap.ts
@@ -7,7 +7,7 @@ const messages = {
 		errors: {
 			tooSmall: {
 				string: {
-					exact: 'Must be exactly {minimum} characters',
+					exact: 'Must be exactly {minimum} character | Must be exactly {minimum} characters',
 					inclusive: 'Must be at least {minimum} characters',
 					notInclusive: 'Must be more than {minimum} characters',
 				},
@@ -35,7 +35,7 @@ describe('makeZodI18nMap', () => {
 		expect(makeZodI18nMap(i18n)).toBeInstanceOf(Function)
 	})
 
-	it('Sould use correct translation', () => {
+	it('Should use correct translation', () => {
 		const i18n = createI18n({
 			legacy: false,
 			locale: 'en',
@@ -45,5 +45,20 @@ describe('makeZodI18nMap', () => {
 		z.setErrorMap(makeZodI18nMap(i18n))
 		const result = getErrorMessage(z.string().min(5).safeParse('12'))
 		expect(result).toEqual('Must be at least 5 characters')
+	})
+
+	it('Should use support plurals translation', () => {
+		const i18n = createI18n({
+			legacy: false,
+			locale: 'en',
+		})
+		i18n.global.setLocaleMessage('en', messages.en)
+		z.setErrorMap(makeZodI18nMap(i18n))
+		expect(getErrorMessage(z.string().length(1).safeParse(''))).toEqual(
+			'Must be exactly 1 character',
+		)
+		expect(getErrorMessage(z.string().length(3).safeParse('12'))).toEqual(
+			'Must be exactly 3 characters',
+		)
 	})
 })


### PR DESCRIPTION
I've attempted to use the plural support as described in the documentation but could not get it to work.  
Even writing a test case reproducing the README instructions did not achieve the expected results.

After digging a bit into how [vue-i18n supported pluralization](https://vue-i18n.intlify.dev/guide/essentials/pluralization#pluralization), I've come to the conclusion that this specific feature does not work anymore (if it did, it probably relied on an older vue-i18n implementation ?) and I'm proposing a fix with a simple test case.

I would be happy to be proven wrong if someone manages to write a test case similar to the one I've added without changing the implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to clarify and expand pluralization support in error messages, including new plural keys and improved usage examples.
- **Bug Fixes**
  - Improved error message translation to correctly handle pluralization based on numeric values.
- **Tests**
  - Added and updated tests to verify correct pluralization in error messages and fixed a typo in test descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->